### PR TITLE
Buf fix for no space between some commands

### DIFF
--- a/src/org/im4java/script/AbstractScriptGenerator.java
+++ b/src/org/im4java/script/AbstractScriptGenerator.java
@@ -271,6 +271,10 @@ abstract public class AbstractScriptGenerator implements ScriptGenerator {
       // dump the line and re-init the line-buffer
       flushLine(false);
       iLineBuffer.append(pBuf);
+	/* Without the following line (appending the empty space) sometimes it ignores spacing between previous variable
+	 * and the next command. Example:- -resize "1024x681"-format "jpg".  notice no space between "1024x681" and -format.
+	 */
+      iLineBuffer.append(" "); 
     } else {
       // the given buffer still fits, so append to the line
       iLineBuffer.append(pBuf);


### PR DESCRIPTION
Sometimes the generated code doesn't have space between the previous command variable and next one.
Example:- -resize "1024x681"-format "jpg".  
notice no space between "1024x681" and -format.

  convert ^
  "C:\Users\xxxx\Desktop\Resized\test2\converted\e.png" ^
  -resize "1024x681"-format "jpg" -quality "33.0" "C:\e.JPG"

Lack of space sometimes works fine but fails for some graphicmagick commands and info/ping commands.